### PR TITLE
Hook.pm: Fixed missing backslash in documentation.

### DIFF
--- a/lib/Taskwarrior/Kusarigama/Hook.pm
+++ b/lib/Taskwarrior/Kusarigama/Hook.pm
@@ -8,7 +8,7 @@ package Taskwarrior::Kusarigama::Hook;
     use Taskwarrior::Kusarigama::Hook;
 
     Taskwarrior::Kusarigama::Hook->new(
-        raw_args => @ARGV
+        raw_args => \@ARGV
     )->run_event( 'launch' );
 
 =head1 DESCRIPTION


### PR DESCRIPTION
There may be other typos, but I found this one. :)