### PR TITLE
[Bugfix] GitCommit: Extend `Plugin` rather than just `Hook`

### DIFF
--- a/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
+++ b/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
@@ -20,7 +20,7 @@ use Git::Repository;
 
 use Moo;
 
-extends 'Taskwarrior::Kusarigama::Hook';
+extends 'Taskwarrior::Kusarigama::Plugin';
 
 with 'Taskwarrior::Kusarigama::Hook::OnExit';
 


### PR DESCRIPTION
Otherwise we don't interpret the `tw` argument and everything fails.

Closes #9.