### PR TITLE
GitCommit: Use the command-line as the git commit message.

### DIFF
--- a/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
+++ b/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
@@ -43,7 +43,7 @@ sub on_exit {
     return unless $git->run( 'status', '--short' );
 
     $git->run( 'add', '.' );
-    $git->run( 'commit', '--message', 'on-exit saving' );
+    $git->run( 'commit', '--message', $self->args );
 
     $lock->release;
 };

--- a/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
+++ b/lib/Taskwarrior/Kusarigama/Plugin/GitCommit.pm
@@ -20,7 +20,7 @@ use Git::Repository;
 
 use Moo;
 
-extends 'Taskwarrior::Kusarigama::Hook';
+extends 'Taskwarrior::Kusarigama::Plugin';
 
 with 'Taskwarrior::Kusarigama::Hook::OnExit';
 


### PR DESCRIPTION
Otherwise one ends up with a million `on-exit saving`. This at least gives
a possibility of understanding what the changes were.

Includes my previous PR, since GitCommit doesn't work without it.